### PR TITLE
Added method for create foundation for input model

### DIFF
--- a/FoundationBuilder/src/Application.cpp
+++ b/FoundationBuilder/src/Application.cpp
@@ -11,6 +11,7 @@ void Application::init(int argc, char** argv)
     cl.add(Option("BuildIn", "write result in one or two files", "b", true));
     cl.add(Option("OutputInASCII", "write result in Binary or ASCII files", "a", true));
     cl.add(Option("Help", "help info", "help", true));
+    cl.add(Option("InflateValue", "specifies how much wider will be foundation than input stl", "w", false, "5.0"));
 
     if (!cl.parse(argc, argv) || cl.specified("help"))
     {
@@ -24,6 +25,7 @@ void Application::init(int argc, char** argv)
     float height = cl.getValueAs<float>("Height");
     bool buildIn = cl.specified("b");
     bool fileType = cl.specified("a");
+    float inflateValue = cl.getValueAs<float>("InflateValue");
 }
 
 // Main logic of the application is here

--- a/GeometryCore/include/Mesh.h
+++ b/GeometryCore/include/Mesh.h
@@ -31,7 +31,7 @@ namespace geom_utils
         bool writeBinary(const std::string& filepath) const;
     };
 
-    Mesh createFoundation(const Mesh& inputModel);
+    Mesh createFoundation(const Mesh& inputModel, const FPoint3D::coord foundation_height);
 
     class MeshHandler
     {

--- a/GeometryCore/include/Mesh.h
+++ b/GeometryCore/include/Mesh.h
@@ -31,7 +31,7 @@ namespace geom_utils
         bool writeBinary(const std::string& filepath) const;
     };
 
-    Mesh createFoundation(const Mesh& inputModel, const FPoint3D::coord foundation_height);
+    Mesh createFoundation(const Mesh& inputModel, const FPoint3D::coord foundationHeight, const FPoint3D::coord inflateValue);
 
     class MeshHandler
     {

--- a/GeometryCore/include/Mesh.h
+++ b/GeometryCore/include/Mesh.h
@@ -31,6 +31,7 @@ namespace geom_utils
         bool writeBinary(const std::string& filepath) const;
     };
 
+    Mesh createFoundation(const Mesh& inputModel);
 
     class MeshHandler
     {

--- a/GeometryCore/include/Triangle.h
+++ b/GeometryCore/include/Triangle.h
@@ -21,6 +21,7 @@ namespace geom_utils
 
         FPoint3D a, b, c;
         FPoint3D getNormal() const;
+        void reverse() { std::swap(a, c); }
     };
 
 }

--- a/GeometryCore/src/Mesh.cpp
+++ b/GeometryCore/src/Mesh.cpp
@@ -189,7 +189,7 @@ namespace geom_utils
 		moveUp(foundationTop, foundationHeight);
 
 		Mesh foundation;
-		std::transform(polygonOfBottom.begin(), polygonOfBottom.end(), std::back_inserter(foundationBottom), &Triangle3D::reverse);
+		for_each(foundationBottom.begin(), foundationBottom.end(), [](Triangle3D& i) {i.reverse(); });
 		for (int i = 0; i < foundationBottom.size(); ++i) {
 			foundation.add(foundationTop[i]);
 

--- a/GeometryCore/src/Mesh.cpp
+++ b/GeometryCore/src/Mesh.cpp
@@ -165,27 +165,22 @@ namespace geom_utils
 		return true;
 	}
 
-	Mesh createFoundation(const Mesh& inputModel) {
+	Mesh createFoundation(const Mesh& inputModel, const FPoint3D::coord foundation_height) {
 		auto from_2d_to_3d_triangle = [](const Triangle2D& input_triangle) { return Triangle3D(FPoint3D(input_triangle.a.x, input_triangle.a.y, 0), FPoint3D(input_triangle.b.x, input_triangle.b.y, 0), FPoint3D(input_triangle.c.x, input_triangle.c.y, 0)); };
 		auto move_up = [](std::vector<Triangle3D>& foundation_part, FPoint3D::coord by) {for_each(foundation_part.begin(), foundation_part.end(), [&](Triangle3D& input) {input.a.z += by; input.b.z += by; input.c.z += by; }); };
 
 		std::vector<Triangle3D> facets(inputModel.getFacets());
 		Polygon verticles;
-		std::vector<FPoint3D::coord> heights_of_verticles;
+
 		for (auto i : facets) {
 			verticles.add(FPoint2D(i.a.x, i.a.y));
 			verticles.add(FPoint2D(i.b.x, i.b.y));
 			verticles.add(FPoint2D(i.c.x, i.c.y));
-			heights_of_verticles.push_back(i.a.z);
-			heights_of_verticles.push_back(i.b.z);
-			heights_of_verticles.push_back(i.c.z);
 		}
 		auto convex = verticles.convexHull();
 		convex.simplify(convex.polygonLength() * 0.01);
 		auto plane_for_foundation = convex.inflate(5.00);
 
-
-		FPoint3D::coord foundation_height = (*std::max_element(heights_of_verticles.begin(), heights_of_verticles.end()) - *std::min_element(heights_of_verticles.begin(), heights_of_verticles.end())) * 0.3;
 		auto polygon_of_bottom = plane_for_foundation.triangulate();
 
 		std::vector<Triangle3D> foundation_bottom;

--- a/UnitTests/MeshTests.h
+++ b/UnitTests/MeshTests.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "UnitTests.h"
 #include "../GeometryCore/include/Mesh.h"
+#include "../GeometryCore/include/AABB.h"
 
 using namespace geom_utils;
 
@@ -128,7 +129,12 @@ DEFINE_TEST_CASE(FoundationCreationFacetsModel)
 {
     Mesh mesh;
     mesh.read("../test_models/facets_155314.stl");
-    Mesh output_mesh = createFoundation(mesh, 6.00);
+    Mesh output_mesh = createFoundation(mesh, 6.00, 5.00);
+    auto facets = output_mesh.getFacets();
+    int i = 0;
+    TEST_ASSERT(facets[i].getNormal() == FPoint3D(0, 0, 1), "Normal of facets on top must be {0, 0, 1}");
+    int j = facets.size() - 1;
+    TEST_ASSERT(facets[j].getNormal() == FPoint3D(0, 0, -1), "Normal of facets on bottom must be {0, 0, -1}");
     output_mesh.writeBinary("../test_models/facets_foundation.stl");
 }
 
@@ -136,7 +142,10 @@ DEFINE_TEST_CASE(FoundationCreationConcativeOutline)
 {
     Mesh mesh;
     mesh.read("../test_models/concave_outline_binary.stl");
-    Mesh output_mesh = createFoundation(mesh, 7.00);
+    Mesh output_mesh = createFoundation(mesh, 7.00, 5.00);
+    auto facets = output_mesh.getFacets();
+    int i = 0, j = facets.size() - 1;
+    TEST_ASSERT(facets[i].a.z - facets[j].a.z == 7.00, "Height of foundation must be 7.00");
     output_mesh.writeBinary("../test_models/concative_foundation.stl");
 }
 
@@ -144,6 +153,12 @@ DEFINE_TEST_CASE(FoundationCreationCube)
 {
     Mesh mesh;
     mesh.read("../test_models/cube_20x20x20_ascii.stl");
-    Mesh output_mesh = createFoundation(mesh, 8.00);
+    
+    Mesh output_mesh = createFoundation(mesh, 8.00, 5.00);
+    AABB3D box(FPoint3D(-15.001, -15.001, -0.001), FPoint3D(15.001, 15.001, 8.001));
+    
+    for (auto i : output_mesh.getFacets()) {
+        TEST_ASSERT((box.contains(i.a) && box.contains(i.b) && box.contains(i.c)), "All points must be in Axis Aligned Boundary Box");
+    }
     output_mesh.writeBinary("../test_models/cube_foundation.stl");
 }

--- a/UnitTests/MeshTests.h
+++ b/UnitTests/MeshTests.h
@@ -128,7 +128,7 @@ DEFINE_TEST_CASE(FoundationCreationFacetsModel)
 {
     Mesh mesh;
     mesh.read("../test_models/facets_155314.stl");
-    Mesh output_mesh = createFoundation(mesh);
+    Mesh output_mesh = createFoundation(mesh, 6.00);
     output_mesh.writeBinary("../test_models/facets_foundation.stl");
 }
 
@@ -136,7 +136,7 @@ DEFINE_TEST_CASE(FoundationCreationConcativeOutline)
 {
     Mesh mesh;
     mesh.read("../test_models/concave_outline_binary.stl");
-    Mesh output_mesh = createFoundation(mesh);
+    Mesh output_mesh = createFoundation(mesh, 7.00);
     output_mesh.writeBinary("../test_models/concative_foundation.stl");
 }
 
@@ -144,6 +144,6 @@ DEFINE_TEST_CASE(FoundationCreationCube)
 {
     Mesh mesh;
     mesh.read("../test_models/cube_20x20x20_ascii.stl");
-    Mesh output_mesh = createFoundation(mesh);
+    Mesh output_mesh = createFoundation(mesh, 8.00);
     output_mesh.writeBinary("../test_models/cube_foundation.stl");
 }

--- a/UnitTests/MeshTests.h
+++ b/UnitTests/MeshTests.h
@@ -123,3 +123,27 @@ DEFINE_TEST_CASE(MeshWriteBinary)
         mesh[0].c.x == 0 && mesh[0].c.y == 1 && mesh[0].c.z == -1
         ), "The written mesh is wrong!");
 }
+
+DEFINE_TEST_CASE(FoundationCreationFacetsModel)
+{
+    Mesh mesh;
+    mesh.read("../test_models/facets_155314.stl");
+    Mesh output_mesh = createFoundation(mesh);
+    output_mesh.writeBinary("../test_models/facets_foundation.stl");
+}
+
+DEFINE_TEST_CASE(FoundationCreationConcativeOutline)
+{
+    Mesh mesh;
+    mesh.read("../test_models/concave_outline_binary.stl");
+    Mesh output_mesh = createFoundation(mesh);
+    output_mesh.writeBinary("../test_models/concative_foundation.stl");
+}
+
+DEFINE_TEST_CASE(FoundationCreationCube)
+{
+    Mesh mesh;
+    mesh.read("../test_models/cube_20x20x20_ascii.stl");
+    Mesh output_mesh = createFoundation(mesh);
+    output_mesh.writeBinary("../test_models/cube_foundation.stl");
+}

--- a/UnitTests/MeshTests.h
+++ b/UnitTests/MeshTests.h
@@ -125,7 +125,7 @@ DEFINE_TEST_CASE(MeshWriteBinary)
         ), "The written mesh is wrong!");
 }
 
-DEFINE_TEST_CASE(FoundationCreationFacetsModel)
+DEFINE_TEST_CASE(FoundationNormals)
 {
     Mesh mesh;
     mesh.read("../test_models/facets_155314.stl");
@@ -135,10 +135,9 @@ DEFINE_TEST_CASE(FoundationCreationFacetsModel)
     TEST_ASSERT(facets[i].getNormal() == FPoint3D(0, 0, 1), "Normal of facets on top must be {0, 0, 1}");
     int j = facets.size() - 1;
     TEST_ASSERT(facets[j].getNormal() == FPoint3D(0, 0, -1), "Normal of facets on bottom must be {0, 0, -1}");
-    output_mesh.writeBinary("../test_models/facets_foundation.stl");
 }
 
-DEFINE_TEST_CASE(FoundationCreationConcativeOutline)
+DEFINE_TEST_CASE(FoundationHeight)
 {
     Mesh mesh;
     mesh.read("../test_models/concave_outline_binary.stl");
@@ -146,10 +145,9 @@ DEFINE_TEST_CASE(FoundationCreationConcativeOutline)
     auto facets = output_mesh.getFacets();
     int i = 0, j = facets.size() - 1;
     TEST_ASSERT(facets[i].a.z - facets[j].a.z == 7.00, "Height of foundation must be 7.00");
-    output_mesh.writeBinary("../test_models/concative_foundation.stl");
 }
 
-DEFINE_TEST_CASE(FoundationCreationCube)
+DEFINE_TEST_CASE(FoundationInBox)
 {
     Mesh mesh;
     mesh.read("../test_models/cube_20x20x20_ascii.stl");
@@ -160,5 +158,4 @@ DEFINE_TEST_CASE(FoundationCreationCube)
     for (auto i : output_mesh.getFacets()) {
         TEST_ASSERT((box.contains(i.a) && box.contains(i.b) && box.contains(i.c)), "All points must be in Axis Aligned Boundary Box");
     }
-    output_mesh.writeBinary("../test_models/cube_foundation.stl");
 }

--- a/UnitTests/TriangleTests.h
+++ b/UnitTests/TriangleTests.h
@@ -12,3 +12,11 @@ DEFINE_TEST_CASE(TriangleGetNormal3D)
    FPoint3D f = tri.getNormal();
    TEST_ASSERT(f.x == 0 && f.y == -1 && f.z == 0, "The normal must be 0, 0, 1!");
 }
+
+DEFINE_TEST_CASE(TriangleReverse)
+{
+    Triangle3D test_triangle({ 1, 1, 0 }, { 0, 1, 0 }, { 0, 1, -1 });
+    test_triangle.reverse();
+    TEST_ASSERT(test_triangle.getNormal() == FPoint3D(0, 1, 0), "Normal of reversed triangle must be 0, 1, 0");
+
+}


### PR DESCRIPTION
For make foundation wider than input model using method `Polygon.inflate`:
![image](https://user-images.githubusercontent.com/24863477/84270752-d72db480-ab33-11ea-9ba0-6d67d476ce97.png)
Height of foundation depends on maximal height of input model by 30%:
![image](https://user-images.githubusercontent.com/24863477/84271141-6a66ea00-ab34-11ea-8165-ca78156a658b.png)
Parts of foundation added to mesh object by sectors in that order, first will be top part, second and thirth will be sides parts, last will be bottom part:
![image](https://user-images.githubusercontent.com/24863477/84271717-1b6d8480-ab35-11ea-9f3d-39f2e91454b0.png)
