### PR TITLE
Added functional for write metadata of foundtion to file

### DIFF
--- a/FoundationBuilder/FoundationBuilder.vcxproj
+++ b/FoundationBuilder/FoundationBuilder.vcxproj
@@ -146,10 +146,12 @@
     <ClCompile Include="src\Application.cpp" />
     <ClCompile Include="src\FoundationFunctions.cpp" />
     <ClCompile Include="src\main.cpp" />
+    <ClCompile Include="src\MetadataOutput.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\Application.h" />
     <ClInclude Include="include\FoundationFunctions.h" />
+    <ClInclude Include="include\MetadataOutput.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/FoundationBuilder/FoundationBuilder.vcxproj.filters
+++ b/FoundationBuilder/FoundationBuilder.vcxproj.filters
@@ -19,12 +19,18 @@
     <ClCompile Include="src\FoundationFunctions.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="src\MetadataOutput.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\Application.h">
       <Filter>include</Filter>
     </ClInclude>
     <ClInclude Include="include\FoundationFunctions.h">
+      <Filter>include</Filter>
+    </ClInclude>
+    <ClInclude Include="include\MetadataOutput.h">
       <Filter>include</Filter>
     </ClInclude>
   </ItemGroup>

--- a/FoundationBuilder/include/MetadataOutput.h
+++ b/FoundationBuilder/include/MetadataOutput.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+
+namespace geom_utils {
+	class Mesh;
+	void writeMetadata(const Mesh& inputModel, const Mesh& foundation, const std::string& metadataFile, const std::string& inputModelName, const std::string& foundationName, const bool& buildIn, const float& timeOfConstructing, const float& foundationMinimalZCoord);
+}

--- a/FoundationBuilder/src/Application.cpp
+++ b/FoundationBuilder/src/Application.cpp
@@ -1,13 +1,15 @@
+#include <chrono>
 #include "../include/Application.h"
 #include "../../GeometryCore/include/Mesh.h"
 #include "../include/FoundationFunctions.h"
+#include "../include/MetadataOutput.h"
 
 // Initialize with command line arguments
 void Application::init(int argc, char** argv)
 {
     cl.add(Option("InputModel", "specifies a file path to input .stl", "i", false, "input.stl"));
     cl.add(Option("OutputModel", "specifies a file path to output .stl", "o", false, "output.stl"));
-    cl.add(Option("MetaData", "specifies a file path to  metadate .json", "m", false, "metadate.json"));
+    cl.add(Option("MetaData", "specifies a file path to  metadata .json", "m", false, "metadata.json"));
     cl.add(Option("Height", "specifies the foundation height", "h", false, "1.0"));
     cl.add(Option("BuildIn", "input and output models are in one file, if true", "b", true));
     cl.add(Option("OutputInASCII", "the output file is in ASCII format, if true", "a", true));
@@ -38,8 +40,12 @@ int Application::run()
     if (!inputMesh.read(cl.getValueAs<std::string>("InputModel"))) return -1;
 
     //create a foundation for it
+    auto start = std::chrono::high_resolution_clock::now();
     geom_utils::Mesh outputMesh = geom_utils::createFoundation(inputMesh, cl.getValueAs<float>("Height"), cl.getValueAs<float>("InflateValue"));
-
+    auto end = std::chrono::high_resolution_clock::now();
+    float foundationCreationTime = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    auto foundation(outputMesh);
+    
     //unite the foundation and input figure in one .stl model, if it is stated
     if (cl.specified("b"))
         outputMesh = geom_utils::integrateFoundationIntoModel(inputMesh, outputMesh);
@@ -51,8 +57,9 @@ int Application::run()
     else
         if (!outputMesh.writeBinary(cl.getValueAs<std::string>("OutputModel"))) return -1;
 
-    //create and write metadata for it
-        //method is not written yet
+    //write metadata to file
+    float foundationMinimalZCoord = outputMesh.getAABB().pmin.z;
+    geom_utils::writeMetadata(inputMesh, foundation, cl.getValueAs<std::string>("MetaData"), cl.getValueAs<std::string>("InputModel"), cl.getValueAs<std::string>("OutputModel"), cl.specified("b"), foundationCreationTime, foundationMinimalZCoord);
 
 
     return 0;

--- a/FoundationBuilder/src/MetadataOutput.cpp
+++ b/FoundationBuilder/src/MetadataOutput.cpp
@@ -1,0 +1,60 @@
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include "../include/MetadataOutput.h"
+#include "../../GeometryCore/include/Triangle.h"
+#include "../../GeometryCore/include/Polygon.h"
+#include "../../GeometryCore/include/Mesh.h"
+#include "../../GeometryCore/include/AABB.h"
+
+namespace geom_utils {
+    void writeMetadata(const Mesh& inputModel, const Mesh& foundation, const std::string& metadataFile, const std::string& inputModelName, const std::string& foundationName, const bool& buildIn, const float& timeOfConstructing, const float& foundationMinimalZCoord) {
+        std::ofstream metaOutput(metadataFile);
+
+        std::stringstream inputModelBoundBox;
+        std::stringstream foundationBoundBox;
+        auto inputModelAABB = inputModel.getAABB();
+        auto foundationAABB = foundation.getAABB();
+        float height = foundationAABB.pmax.z - foundationAABB.pmin.z;
+        inputModelBoundBox << "[" << inputModelAABB.pmin.x << ", " << inputModelAABB.pmax.x << ", " << inputModelAABB.pmin.y << ", " << inputModelAABB.pmax.y << ", " << inputModelAABB.pmin.z << ", " << inputModelAABB.pmax.z << "]";
+        foundationBoundBox << "[" << foundationAABB.pmin.x << ", " << foundationAABB.pmax.x << ", " << foundationAABB.pmin.y << ", " << foundationAABB.pmax.y << ", " << foundationMinimalZCoord << ", " << foundationMinimalZCoord+height << "]";
+
+        auto foundationFacets = foundation.getFacets();
+        Polygon foundationTopPolygon;
+        for (int i = 0; i < foundationFacets.size() - 3; i += 4) {
+            if (i == 0) {
+                foundationTopPolygon.add(FPoint2D(foundationFacets[i].b.x, foundationFacets[i].b.y));
+            }
+            foundationTopPolygon.add(FPoint2D(foundationFacets[i].c.x, foundationFacets[i].c.y));
+            if (i == foundationFacets.size() - 4) {
+                foundationTopPolygon.add(FPoint2D(foundationFacets[i].a.x, foundationFacets[i].a.y));
+            }
+        }
+        if (foundationTopPolygon.orientation()) {
+            std::reverse(foundationTopPolygon.begin(), foundationTopPolygon.end());
+        }
+        float polygonLength = foundationTopPolygon.polygonLength();
+
+        float polygonArea = foundationTopPolygon.area();
+        int numOfFacets = foundation.getFacets().size();
+
+        metaOutput << "{" << std::endl \
+            << "\t\"model\": {" << std::endl \
+            << "\t\tname: \"" << inputModelName << "\"," << std::endl \
+            << "\t\tbbox: " << inputModelBoundBox.str() << std::endl \
+            << "\t}," << std::endl \
+            << "\t\"foundation\": {" << std::endl\
+            << "\t\tname: \""  << foundationName << "\"," << std::endl \
+            << "\t\tbbox: " << foundationBoundBox.str() << "," << std::endl \
+            << "\t\tis_build_in: " << (buildIn ? "true" : "false") << "," << std::endl \
+            << "\t\theight: " << height << "," << std::endl \
+            << "\t\tpolygon_length: " << polygonLength << "," << std::endl \
+            << "\t\tpolygon_area: " << polygonArea << "," << std::endl \
+            << "\t\tnum_of_facets: " << numOfFacets << "," << std::endl \
+            << "\t\ttime_of_constructing: " << timeOfConstructing << std::endl \
+            << "\t}" << std::endl \
+            << "}" << std::endl;
+        metaOutput.close();
+    }
+}

--- a/UnitTests/ApplicationTests.h
+++ b/UnitTests/ApplicationTests.h
@@ -27,22 +27,22 @@ DEFINE_TEST_CASE(ApplicationRun)
 
     //check whether help works correct
     system("FoundationBuilder.exe -help > ApplicationRun_test.txt");
-    TEST_ASSERT(!isFileExist("output.stl") && !isFileExist("metadate.json"), "Application must not create any files if help is stated!");
+    TEST_ASSERT(!isFileExist("output.stl") && !isFileExist("metadata.json"), "Application must not create any files if help is stated!");
     std::remove("ApplicationRun_test.txt");
 
     //check whether program works with random data
     system("FoundationBuilder.exe some random data > ApplicationRun_test.txt");
-    TEST_ASSERT(!isFileExist("output.stl") && !isFileExist("metadate.json"), "Application must not create any files if random data is stated!");
+    TEST_ASSERT(!isFileExist("output.stl") && !isFileExist("metadata.json"), "Application must not create any files if random data is stated!");
     std::remove("ApplicationRun_test.txt");
 
     //check whether program works with wrong data
     system("FoundationBuilder.exe -i blabla.txt -o alsoBlabla.txt -h -2 > ApplicationRun_test.txt");
-    TEST_ASSERT(!isFileExist("output.stl") && !isFileExist("metadate.json"), "Application must not create any files if wrong data is stated!");
+    TEST_ASSERT(!isFileExist("output.stl") && !isFileExist("metadata.json"), "Application must not create any files if wrong data is stated!");
     std::remove("ApplicationRun_test.txt");
 
     //check whether program works without data
     system("FoundationBuilder.exe > ApplicationRun_test.txt");
-    TEST_ASSERT(!isFileExist("output.stl") && !isFileExist("metadate.json"), "Application must not create any files if data is not stated!");
+    TEST_ASSERT(!isFileExist("output.stl") && !isFileExist("metadata.json"), "Application must not create any files if data is not stated!");
     std::remove("ApplicationRun_test.txt");
 
     //check whether program works with correct data (foundation is integrated)
@@ -71,6 +71,7 @@ DEFINE_TEST_CASE(ApplicationRun)
 
     //delete the copied executor
     std::remove("FoundationBuilder.exe");
+    std::remove("metadata.json");
 }
 
 
@@ -88,6 +89,7 @@ DEFINE_TEST_CASE(FoundationNormals)
     std::remove("unitTestFile.txt");
     std::remove("../test_models/outputModel.stl");
     std::remove("FoundationBuilder.exe");
+    std::remove("metadata.json");
 }
 
 
@@ -104,6 +106,7 @@ DEFINE_TEST_CASE(FoundationHeight)
     std::remove("unitTestFile.txt");
     std::remove("../test_models/outputModel.stl");
     std::remove("FoundationBuilder.exe");
+    std::remove("metadata.json");
 }
 
 
@@ -121,6 +124,7 @@ DEFINE_TEST_CASE(FoundationInBox)
 
     std::remove("unitTestFile.txt");
     std::remove("../test_models/outputModel.stl");
+    std::remove("metadata.json");
     std::remove("FoundationBuilder.exe");
 }
 
@@ -138,6 +142,29 @@ DEFINE_TEST_CASE(PlacingFoundationUnderFigure)
     }
 
     std::remove("unitTestFile.txt");
+    std::remove("metadata.json");
     std::remove("../test_models/outputModel.stl");
     std::remove("FoundationBuilder.exe");
+}
+
+DEFINE_TEST_CASE(CreatingMetadataFile)
+{
+    copyFile("../x64/Debug/FoundationBuilder.exe", "FoundationBuilder.exe");
+    system("FoundationBuilder.exe -i ../test_models/cube_20x20x20_ascii.stl -o ../test_models/outputModel.stl -h 4 -w 5 -b -m meta.json");
+    std::ifstream metadataFile;
+    metadataFile.open("meta.json");
+    TEST_ASSERT(metadataFile.is_open(), "Metadata file \"meta.json\" must be created");
+    metadataFile.close();
+    std::remove("FoundationBuilder.exe");
+    std::remove("../test_models/outputModel.stl");
+    std::remove("meta.json");
+
+    copyFile("../x64/Debug/FoundationBuilder.exe", "FoundationBuilder.exe");
+    system("FoundationBuilder.exe -i ../test_models/cube_20x20x20_ascii.stl -o ../test_models/outputModel.stl -h 4 -w 5 -b");
+    metadataFile.open("metadata.json");
+    TEST_ASSERT(metadataFile.is_open(), "Metadata file with default value \"metadata.json\" must be created");
+    metadataFile.close();
+    std::remove("FoundationBuilder.exe");
+    std::remove("metadata.json");
+    std::remove("../test_models/outputModel.stl");
 }


### PR DESCRIPTION
In result metadata file looks like:

![image](https://user-images.githubusercontent.com/24863477/84891167-19ab4000-b0a4-11ea-853c-5f46ec15d8a0.png)
sorry for image, github was write text without tabs

For find length and area of polygon I get points from facets of top and add they to polygon

Method writeMetadata accepts argument foundationMinimalZCoord and copy of original foundation, because after integrating with input model, in case when we get console argument -b, foundation contains input model too and hard to take other parameters of foundation