### PR TITLE
Passing arguments by value for trivial types

### DIFF
--- a/FoundationBuilder/include/MetadataOutput.h
+++ b/FoundationBuilder/include/MetadataOutput.h
@@ -3,5 +3,5 @@
 
 namespace geom_utils {
 	class Mesh;
-	void writeMetadata(const Mesh& inputModel, const Mesh& foundation, const std::string& metadataFile, const std::string& inputModelName, const std::string& foundationName, const bool& buildIn, const float& timeOfConstructing, const float& foundationMinimalZCoord);
+	void writeMetadata(const Mesh& inputModel, const Mesh& foundation, std::string metadataFile, std::string inputModelName, std::string foundationName, bool buildIn, float timeOfConstructing, float foundationMinimalZCoord);
 }

--- a/FoundationBuilder/src/MetadataOutput.cpp
+++ b/FoundationBuilder/src/MetadataOutput.cpp
@@ -9,7 +9,7 @@
 #include "../../GeometryCore/include/AABB.h"
 
 namespace geom_utils {
-    void writeMetadata(const Mesh& inputModel, const Mesh& foundation, const std::string& metadataFile, const std::string& inputModelName, const std::string& foundationName, const bool& buildIn, const float& timeOfConstructing, const float& foundationMinimalZCoord) {
+    void writeMetadata(const Mesh& inputModel, const Mesh& foundation, std::string metadataFile, std::string inputModelName, std::string foundationName, bool buildIn, float timeOfConstructing, float foundationMinimalZCoord) {
         std::ofstream metaOutput(metadataFile);
 
         std::stringstream inputModelBoundBox;


### PR DESCRIPTION
Changed arguments passing by referance to passing by value for trivial types in function writeMetadata
